### PR TITLE
Add Joker rules

### DIFF
--- a/yonac.tex
+++ b/yonac.tex
@@ -56,24 +56,26 @@ The four Aces (i.e. the Ace of Spades, the Ace of Hearts, the Ace of Clubs
 and the Ace of Diamonds) are special and are described below. All other
 cards have no special attributes.
 
-Of the Aces, the Ace of Spades and the Ace of Diamonds take effect
-immediately upon collection. The Ace of Hearts and the Ace of Clubs take
-effect on a subsequent turn.
+A card is described as ``Potent'' if its special attribute may be used.
 
 \subsubsection{The Ace of Spades}
 Picking up the Ace of Spades, except when using the Ace of Clubs or the
-Ace of Hearts, will result in a loss.
+Ace of Hearts, will result in a loss. The Ace of Spades is always Potent.
 
 \subsubsection{The Ace of Diamonds}
-The Ace of Diamonds forces you to add more cards to the cards being
-evaluated.
+The Ace of Diamonds forces you to add more cards to the Set. The Ace of
+Diamonds is Potent on collection and is no longer Potent when it is used
+to add more cards to the Set.
 
 \subsubsection{The Ace of Hearts}
 The Ace of Hearts allows you to pick up the Ace of Spades once without
-losing. The usage of this card is described in \ref{par:spadeshearts}.
+losing. The Ace of Hearts becomes Potent after you collect it and your
+turn finishes. The usage of this card is described in
+\ref{par:spadeshearts}.
 
 \subsubsection{The Ace of Clubs}
-The Ace of Clubs gives you one chance to win instantly. The usage of
+The Ace of Clubs gives you one chance to win instantly. The Ace of Clubs
+becomes Potent after you collect it and your turn finishes. The usage of
 this card is described in \ref{sec:playac}.
 
 \subsection{Gameplay}
@@ -94,8 +96,8 @@ you may use the Ace of Clubs if you have it set aside.
 \label{sec:collecting}
 
 Each player has a stack of cards, called the Stash, into which collected
-cards are put. Any Aces put into your Stash may not be used again until
-the Ace returns to the Pile.
+cards are put. Any cards put into your Stash lose their Potency and may
+not be used again until the card returns to the Pile.
 
 \paragraph{}
 \label{par:set}
@@ -108,33 +110,35 @@ If the Set does not contain any Aces, put the Set into your Stash.
 Your turn is now over and play proceeds to the next player. 
 
 \paragraph{}
-If the Set contains the Ace of Spades and you do not have the Ace of
-Hearts set aside, you lose and all your cards are reshuffled into the
-Pile. Play proceeds to the next player.
+If the Set contains the Ace of Spades and you do not have a Potent Ace
+of Hearts, you lose and all your cards are reshuffled into the Pile.
+Play proceeds to the next player.
 
 \paragraph{}
 \label{par:spadeshearts}
-If the Set contains the Ace of Spades and you have the Ace of Hearts set
-aside, place the Ace of Hearts in your Stash and reshuffle the Set into
-the Pile. The Ace of Hearts may not be used again until it returns to
-the Pile. Note that the Ace of Hearts is not treated specially if it is
-in the Set with the Ace of Spades; it must have been collected and set
-aside in a previous turn for this case to apply. Play proceeds to the
-next player.
+If the Set contains the Ace of Spades and you have a Potent Ace of
+Hearts, place the Ace of Hearts in your Stash and reshuffle the Set into
+the Pile. The Ace of Hearts is now not Potent and it may not be used
+again until it returns to the Pile. Note that the Ace of Hearts is not
+Potent if it is in the Set with the Ace of Spades; it must have been
+collected and set aside in a previous turn for this case to apply. Play
+proceeds to the next player.
 
 \paragraph{}
-If the Set contains the Ace of Diamonds, pick up one or more cards from
-the Pile and add it to the Set. Re-evaluate the new Set, ignoring the
-Ace of Diamonds.
+If the Set contains a Potent Ace of Diamonds, pick up one or more cards
+from the Pile and add them to the Set. Re-evaluate the new Set, with the
+Ace of Diamonds now no longer Potent.
 
 \paragraph{}
-If the Set contains the Ace of Clubs, put the Ace of Clubs aside. You
-may play it in a later turn as described in \ref{sec:playac}.
+If the Set contains the Ace of Clubs, put the Ace of Clubs aside; the
+Ace of Clubs is now Potent. You may play it in a later turn as described
+in \ref{sec:playac}.
 
 \paragraph{}
-If the Set contains the Ace of Hearts, put the Ace of Hearts aside. It
-will protect you if you collect the Ace of Spades in a later turn as
-previously described in \ref{par:spadeshearts}.
+If the Set contains the Ace of Hearts, put the Ace of Hearts aside; the
+Ace of Hearts is now Potent. It will protect you if you collect the Ace
+of Spades in a later turn as previously described in
+\ref{par:spadeshearts}.
 
 Put the remaining cards in the Set into your Stash. Your turn is now
 over and play proceeds to the next player.
@@ -142,9 +146,10 @@ over and play proceeds to the next player.
 \subsubsection{Playing the Ace of Clubs}
 \label{sec:playac}
 
-If you have set aside the Ace of Clubs, you may choose to play it
-instead of collecting cards. Once played and put in your Stash, the Ace
-of Clubs may not be used again until it is returned to the Pile.
+If you have a Potent Ace of Clubs, you may choose to play it instead of
+collecting cards. Once played and put in your Stash, the Ace of Clubs
+loses its Potency and may not be used again until it is returned to the
+Pile.
 
 \paragraph{}
 To play the Ace of Clubs, declare that you will be playing the Ace of
@@ -159,8 +164,8 @@ and play proceeds to the next player.
 If the card is the Ace of Spades, play stops and you win the game.
 
 \paragraph{}
-If the card is the Ace of Hearts, put it aside. Your turn is over and
-play proceeds to the next player.
+If the card is the Ace of Hearts, put it aside; the Ace of Hearts is now
+Potent. Your turn is over and play proceeds to the next player.
 
 \paragraph{}
 If the card is the Ace of Diamonds, put it in your Stash and pick up one
@@ -194,8 +199,9 @@ In the event of a tie, the tied player who has the Ace of Hearts wins.
 If no one has the Ace of Hearts, the tied player with the Ace of Clubs
 wins. If no one has the Ace of Hearts or the Ace of Clubs, the tied
 player with the Ace of Diamonds wins. If no one has any Aces, the tied
-player who had a turn last wins. Note that if none of the remaining
-players have had a turn, then the player last in the queue wins.
+player who had a turn last wins. Note that these Aces do not need to be
+Potent to count. Also note that if none of the remaining players have
+had a turn, then the player last in the queue wins.
 
 \section{Glossary}
 \begin{description}
@@ -205,6 +211,8 @@ players have had a turn, then the player last in the queue wins.
   \item[Pile](\ref{sec:gameplay})\\
     The uncollected cards spread out. In each turn, all cards are taken
     from the Pile.
+  \item[Potent](\ref{sec:cards})\\
+    Describes a card whose special attribute may be used.
   \item[Set](\ref{par:set})\\
     The cards picked up during a turn.
   \item[Stash](\ref{sec:collecting})\\

--- a/yonac.tex
+++ b/yonac.tex
@@ -188,6 +188,12 @@ and play proceeds to the next player.
 If the card is the Ace of Spades, play stops and you win the game.
 
 \paragraph{}
+If the card is a Joker, swap it for another player's Potent Ace as
+described in \ref{par:jokersetnoaces}. If no player has a Potent Ace,
+you may not perform the swap. Evaluate the new card as if that was the
+card you picked up.
+
+\paragraph{}
 If the card is the Ace of Hearts, put it aside; the Ace of Hearts is now
 Potent. Your turn is over and play proceeds to the next player.
 

--- a/yonac.tex
+++ b/yonac.tex
@@ -267,6 +267,8 @@ The special attributes for the Ace of Hearts and the Ace of Clubs were
 suggested by Gaetan Boue. The special attribute for the Ace of Diamonds
 was suggested by Onie Tam.
 
+Joker rules were suggested by Johann Tutor.
+
 The rules were refined and formalized by Johann Tutor and Gaetan Boue.
 
 This document was written by Johann Tutor.

--- a/yonac.tex
+++ b/yonac.tex
@@ -132,11 +132,11 @@ proceeds to the next player.
 
 \paragraph{}
 \label{par:jokersetaces}
-If the Set contains a Joker and there are Aces in the Set, remove the
-Aces and shuffle them into the Pile. Note that if the Set contains the
-Ace of Spades, the rules for the Ace of Spades apply instead. Put the
-rest of the Set, including any Jokers, into your Stash. Your turn is now
-over and play proceeds to the next player.
+If the Set contains a Joker and there are Aces in the Set, including an
+Impotent Ace of Diamonds if present, remove the Aces and shuffle them into the
+Pile. Note that if the Set contains the Ace of Spades, the rules for the Ace of
+Spades apply instead. Put the rest of the Set, including any Jokers, into your
+Stash. Your turn is now over and play proceeds to the next player.
 
 \paragraph{}
 \label{par:jokersetnoaces}

--- a/yonac.tex
+++ b/yonac.tex
@@ -41,7 +41,7 @@ of Spades'', described in Bob Phillips'
 
 \section{Requirements}
 
-Yonac uses a standard deck of cards (jokers optional). Any number of
+Yonac uses a standard deck of cards (Jokers optional). Any number of
 players may play.
 
 \section{Rules}

--- a/yonac.tex
+++ b/yonac.tex
@@ -233,6 +233,7 @@ player who had a turn last wins. Note that these Aces do not need to be
 Potent to count. Also note that if none of the remaining players have
 had a turn, then the player last in the queue wins.
 
+\newpage
 \section{Glossary}
 \begin{description}
   \item[Elimination Phase](\ref{sec:elimination})\\

--- a/yonac.tex
+++ b/yonac.tex
@@ -52,8 +52,8 @@ collecting the Ace of Spades.
 \subsection{The Cards}
 \label{sec:cards}
 
-The four Aces (i.e. the Ace of Spades, the Ace of Hearts, the Ace of Clubs
-and the Ace of Diamonds) are special and are described below. All other
+The four Aces (i.e. the Ace of Spades, the Ace of Hearts, the Ace of Clubs and
+the Ace of Diamonds) and Jokers are special and are described below. All other
 cards have no special attributes.
 
 A card is described as ``Potent'' if its special attribute may be used.
@@ -77,6 +77,12 @@ turn finishes. The usage of this card is described in
 The Ace of Clubs gives you one chance to win instantly. The Ace of Clubs
 becomes Potent after you collect it and your turn finishes. The usage of
 this card is described in \ref{sec:playac}.
+
+\subsubsection{The Joker}
+If Jokers are in play, a Joker will remove Aces from a Set, or if there
+are no Aces in the Set, you can swap it for another player's Potent
+Ace. The usage of this card is described in \ref{par:jokersetaces} and
+\ref{par:jokersetnoaces}.
 
 \subsection{Gameplay}
 \label{sec:gameplay}
@@ -123,6 +129,24 @@ again until it returns to the Pile. Note that the Ace of Hearts is not
 Potent if it is in the Set with the Ace of Spades; it must have been
 collected and set aside in a previous turn for this case to apply. Play
 proceeds to the next player.
+
+\paragraph{}
+\label{par:jokersetaces}
+If the Set contains a Joker and there are Aces in the Set, remove the
+Aces and shuffle them into the Pile. Note that if the Set contains the
+Ace of Spades, the rules for the Ace of Spades apply instead. Put the
+rest of the Set, including any Jokers, into your Stash. Your turn is now
+over and play proceeds to the next player.
+
+\paragraph{}
+\label{par:jokersetnoaces}
+If the Set contains a Joker and there are no Aces in the Set, swap the
+Joker with a Potent Ace of another player if one exists.  Remember that
+Aces in a player's Stash are not Potent. To perform the swap, place the
+Joker into the other player's Stash. Take the Potent Ace and put it into
+your Set. Do this for every Joker in your Set. If there are no Potent
+Aces, then you many not perform a swap. After this, the Jokers lose
+their Potency. Continue to evaluate the Set, including any swapped Aces.
 
 \paragraph{}
 If the Set contains a Potent Ace of Diamonds, pick up one or more cards


### PR DESCRIPTION
Add the following rules for Jokers:
- If a Joker is picked up with any Aces except for the Ace of Spades, all Aces from the Set are returned to the Pile. This includes any Impotent Ace of Diamonds. If the Ace of Spades was picked up with the Joker, the rules for the Ace of Spades applies instead.
  - Ace of Spades rules must take precedence otherwise a player can pick up the whole Pile on the first turn, leaving just the Aces.
- If a Joker is picked up without any Aces, the Joker is swapped with any Potent Ace of an opponent.
